### PR TITLE
Ignore vendor/bundle from callstack

### DIFF
--- a/lib/dblint/checks/base.rb
+++ b/lib/dblint/checks/base.rb
@@ -8,7 +8,7 @@ module Dblint
       end
 
       def find_main_app_caller(callstack)
-        main_app_caller = callstack.find { |f| f.start_with?(Rails.root.to_s) }
+        main_app_caller = callstack.find { |f| f.start_with?(Rails.root.to_s) && !f.include?("/vendor/bundle") }
         main_app_caller.slice!(Rails.root.to_s + '/')
         main_app_dir    = main_app_caller[/^\w+/]
         return if %w(spec test).include?(main_app_dir)


### PR DESCRIPTION
When deploying and vendoring gems, this messes with the functionality
that finds the main app caller stack trace. Since vendored gems
typically go under the `"#{Rails.root}/vendor/bundle` which causes the
main_app_caller function to return lines like:
`/home/ubuntu/voray/vendor/bundle/ruby/2.3.0/gems/dblint-0.1.0/lib/dblint/checks/missing_index.rb:42`
rather than a call stack from within the app.

This messes with the .dblint.yml ignore list as well as ignoring
failures from the spec and test directory.

This was found while running tests in circle ci.

![screen shot 2016-04-26 at 5 21 01 pm](https://cloud.githubusercontent.com/assets/230639/14854639/7dbf870c-0c5e-11e6-8875-b28dbc353b59.png)
