### PR TITLE
Rails 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: ruby
 rvm:
-  - 1.9.3-p551
-  - 2.0.0-p648
-  - 2.1.8
+  - 2.2.2
   - 2.2.4
   - 2.3.1
-  - rbx-3.20
+  - rbx-3.29
 addons:
   postgresql: 9.4
 env:

--- a/lib/dblint/checks/long_held_lock.rb
+++ b/lib/dblint/checks/long_held_lock.rb
@@ -61,7 +61,7 @@ module Dblint
         @existing_ids = {}
 
         ActiveRecord::Base.connection.tables.each do |table|
-          next if table == 'schema_migrations'
+          next if %w(schema_migrations ar_internal_metadata).include?(table)
           @existing_ids[table] = ActiveRecord::Base.connection.select_values("SELECT id FROM #{table}", 'DBLINT').map(&:to_i)
         end
       end

--- a/lib/dblint/rails_integration.rb
+++ b/lib/dblint/rails_integration.rb
@@ -27,8 +27,17 @@ module Dblint
 
       CHECKS.each do |check_klass|
         check = check_instance_for_connection(payload[:connection_id], check_klass)
-        check.statement_finished(name, id, payload)
+        check.statement_finished(name, id, payload_from_version(ActiveRecord::VERSION::MAJOR, payload))
       end
+    end
+
+    private
+
+    def payload_from_version(version, payload)
+      return payload if version == 4
+
+      compatible_binds = payload[:binds].map { |bind| [bind, bind.value] }
+      payload.merge(binds: compatible_binds)
     end
   end
 

--- a/spec/lib/rails_integration_spec.rb
+++ b/spec/lib/rails_integration_spec.rb
@@ -1,0 +1,83 @@
+require 'spec_helper'
+
+RSpec.describe Dblint::RailsIntegration do
+  subject { Dblint::RailsIntegration.new }
+
+  describe 'private#payload_from_version' do
+    describe 'AR version 4' do
+      let(:payload) {
+        {
+          sql: 'SELECT  "users".* FROM "users" WHERE "users"."id" = $1 AND "users"."visibility" = $2 ORDER BY "users"."id" ASC LIMIT 1',
+          name: 'User Load',
+          connection_id: 70108286766780,
+          statement_name: nil,
+          binds: [
+            [ActiveRecord::ConnectionAdapters::PostgreSQLColumn.new(
+              'id',
+              nil,
+              ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Uuid.new,
+              'uuid',
+              false,
+              'uuid_generate_v4()'),
+            '3b12f5f9-3d6c-4fd0-ba18-dc02a2b631af'],
+            [ActiveRecord::ConnectionAdapters::PostgreSQLColumn.new(
+              'visibility',
+              'public',
+              ActiveRecord::Type::String.new,
+              'character varying',
+              false),
+            'public']
+          ]
+        }
+      }
+
+      it 'returns payload' do
+        expect(subject.send(:payload_from_version, 4, payload)).to eq(payload)
+      end
+    end
+
+    describe "AR version 5" do
+      let(:payload) {
+        {
+          sql: 'SELECT  "users".* FROM "users" WHERE "users"."id" = $1 AND "users"."visibility" = $2 ORDER BY "users"."id" ASC LIMIT 1',
+          name: 'User Load',
+          connection_id: 70108286766780,
+          statement_name: nil,
+          binds: [
+            ActiveRecord::Relation::QueryAttribute.new(
+              'id',
+              '3b12f5f9-3d6c-4fd0-ba18-dc02a2b631af',
+              ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Uuid.new
+            ),
+            ActiveRecord::Relation::QueryAttribute.new(
+              'visibility',
+              'public',
+              ActiveModel::Type::String.new
+            )
+          ]
+        }
+      }
+
+      it 'creates backwards compatible version of binds' do
+        result = subject.send(:payload_from_version, 5, payload)
+        id = result[:binds].first
+        visibility = result[:binds].second
+
+        expect(id[0].name).to eq('id')
+        expect(id[1]).to eq('3b12f5f9-3d6c-4fd0-ba18-dc02a2b631af')
+
+        expect(visibility[0].name).to eq('visibility')
+        expect(visibility[1]).to eq('public')
+      end
+
+      it 'preserves base payload attributes' do
+        result = subject.send(:payload_from_version, 5, payload)
+
+        expect(result[:sql]).to eq(payload[:sql])
+        expect(result[:name]).to eq(payload[:name])
+        expect(result[:conection_id]).to eq(payload[:conection_id])
+        expect(result[:statement_name]).to eq(payload[:statement_name])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Necessary changes for Rails 5.

There is a new table that rails adds to the database:
`ar_internal_metadata`
Not unlike `schema_migrations` we need to add this to the ignore list as
it contains no id column.

The format of the payload passed to `add_new_locks_held` has changed.
The old format:

```
 [[#<ActiveRecord::ConnectionAdapters::PostgreSQLColumn:0x007fe3ef8e1e78
   @array=false,
   @cast_type=#<ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Uuid:0x007fe3eccaa120
@limit=nil, @precision=nil, @scale=nil>,
   @default=nil,
   @default_function="uuid_generate_v4()",
   @name="id",
   @null=false,
   @sql_type="uuid">,
  "a97839f3-daa0-4d9c-b9fe-47a7e403fe50"]]
```

The new format:

```
[#<ActiveRecord::Relation::QueryAttribute:0x007fa4e144fcb8
  @name="id",
  @original_attribute=nil,
  @type=#<ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Uuid:0x007fa4dbbbe720
@limit=nil, @precision=nil, @scale=nil>,
  @value="a97839f3-daa0-4d9c-b9fe-47a7e403fe50",
  @value_before_type_cast="a97839f3-daa0-4d9c-b9fe-47a7e403fe50",
  @value_for_database="a97839f3-daa0-4d9c-b9fe-47a7e403fe50">]
```
